### PR TITLE
Update authentication.md

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -83,7 +83,7 @@ server {
   location /v2/ {
     # Do not allow connections from docker 1.5 and earlier
     # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
-    if (\$http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*\$" ) {
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*\$" ) {
       return 404;
     }
 
@@ -93,10 +93,10 @@ server {
     add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
 
     proxy_pass                          http://docker-registry;
-    proxy_set_header  Host              \$http_host;   # required for docker client's sake
-    proxy_set_header  X-Real-IP         \$remote_addr; # pass on real client's IP
-    proxy_set_header  X-Forwarded-For   \$proxy_add_x_forwarded_for;
-    proxy_set_header  X-Forwarded-Proto \$scheme;
+    proxy_set_header  Host              $http_host;   # required for docker client's sake
+    proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+    proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Proto $scheme;
     proxy_read_timeout                  900;
   }
 }
@@ -118,7 +118,7 @@ cat <<EOF > docker-compose.yml
 nginx:
   image: "nginx:1.9"
   ports:
-    - 5043:443
+    - 443:443
   links:
     - registry:registry
   volumes:


### PR DESCRIPTION
Removes escapes from dollar signs in registry.conf example that break the nginx config.
Also sets the nginx port to use host's 443
